### PR TITLE
Ajout : boutons de partage sur les réseaux sociaux pour les points d'observations

### DIFF
--- a/backend/static/css/site.css
+++ b/backend/static/css/site.css
@@ -14,6 +14,78 @@
   height: 315px;
 }
 
+.share-wrapper {
+  display: flex;
+  align-items: center;
+  background-color: #f8f9fa;
+  border-radius: 8px;
+  padding: 8px 16px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.share-label {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #555;
+  margin-right: 12px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.social-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.social-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+  color: white;
+}
+
+.social-button:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.social-button i {
+  font-size: 20px;
+  color: #fff;
+}
+
+.facebook {
+  background-color: #3b5998;
+}
+.twitter {
+  background-color: #1da1f2;
+}
+.linkedin {
+  background-color: #0077b5;
+}
+.mastodon {
+  background-color: #6364ff;
+}
+.whatsapp {
+  background-color: #25d366;
+}
+.telegram {
+  background-color: #0088cc;
+}
+.reddit {
+  background-color: #ff4500;
+}
+.pinterest {
+  background-color: #e60023;
+}
+.email {
+  background-color: #6c757d;
+}
+
 @media (min-width: 576px) {
   .page-site .info {
     box-shadow: 0px 0px 7px 4px rgb(0 0 0 / 18%);

--- a/backend/tpl/components/social_networks.jinja
+++ b/backend/tpl/components/social_networks.jinja
@@ -1,0 +1,53 @@
+<div class="social-buttons">
+  {% if dbconf.social_networks.facebook %}
+        <a class="social-button facebook" 
+          href="https://www.facebook.com/sharer/sharer.php?u={{ url_for('main.sites', id=site.id_site, _external=True) }}&quote={{ site.name_site }}" 
+          target="_blank" 
+          rel="noopener noreferrer"
+          title="Partager sur Facebook">
+          <i class="icon ion-logo-facebook"></i>
+        </a>
+  {% endif %}
+  {% if dbconf.social_networks.twitter %}
+    <a class="social-button twitter"
+        href="https://twitter.com/intent/tweet?url={{ url_for('main.sites', id=site.id_site, _external=True) }}&text={{ site.name_site }}&hashtags=geopaysages"
+        target="_blank" rel="noopener noreferrer" title="Partager sur Twitter">
+      <i class="icon ion-logo-twitter"></i>
+    </a>
+  {% endif %}
+  {% if dbconf.social_networks.linkedin %}
+    <a class="social-button linkedin"
+        href="https://www.linkedin.com/shareArticle?mini=true&url={{ url_for('main.sites', id=site.id_site, _external=True) }}&title={{ site.name_site }}"
+        target="_blank" rel="noopener noreferrer" title="Partager sur LinkedIn">
+      <i class="icon ion-logo-linkedin"></i>
+    </a>
+  {% endif %}
+  {% if dbconf.social_networks.whatsapp %}
+    <a class="social-button whatsapp"
+        href="https://wa.me/?text={{ site.name_site }}%20{{ url_for('main.sites', id=site.id_site, _external=True) }}"
+        target="_blank" rel="noopener noreferrer" title="Partager sur WhatsApp">
+      <i class="icon ion-logo-whatsapp"></i>
+    </a>
+  {% endif %}
+  {% if dbconf.social_networks.reddit %}
+    <a class="social-button reddit"
+        href="https://www.reddit.com/submit?url={{ url_for('main.sites', id=site.id_site, _external=True) }}&title={{ site.name_site }}"
+        target="_blank" rel="noopener noreferrer" title="Partager sur Reddit">
+      <i class="icon ion-logo-reddit"></i>
+    </a>
+  {% endif %}
+  {% if dbconf.social_networks.pinterest %}
+    <a class="social-button pinterest"
+        href="https://pinterest.com/pin/create/button/?url={{ url_for('main.sites', id=site.id_site, _external=True) }}&description={{ site.name_site }}"
+        target="_blank" rel="noopener noreferrer" title="Partager sur Pinterest">
+      <i class="icon ion-logo-pinterest"></i>
+    </a>
+  {% endif %}
+  {% if dbconf.social_networks.email %}
+    <a class="social-button email"
+        href="mailto:?subject={{ site.name_site }}&body={{ site.name_site }}%20{{ url_for('main.sites', id=site.id_site, _external=True) }}"
+        target="_blank" rel="noopener noreferrer" title="Partager par Email">
+      <i class="icon ion-md-mail"></i>
+    </a>
+  {% endif %}
+</div>

--- a/backend/tpl/site.jinja
+++ b/backend/tpl/site.jinja
@@ -26,6 +26,25 @@
 <script src="{{ url_for('static', filename='js/sites-utils.js') }}"></script>
 <script src="{{ url_for('static', filename='js/site.js') }}"></script>
 <script src="{{ url_for('static', filename='js/comparator-v' + comparator_version|string + '.js') }}"></script>
+{% if site %}
+<meta property="og:title" content="{{ site.name_site }}" />
+<meta property="og:description" content="{{ site.legend_site }}" />
+<meta property="og:locale" content="en_UK" />
+<meta property="twitter:title" content="{{ site.name_site }}" />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="{{ url_for('main.sites', id=site.id_site, _external=True) }}" />
+<meta name="twitter:card" content="summary_large_image" />
+{% if photos %}
+  <meta property="og:image" content="{{ request.url_root }}api/thumbor/presets/200x200/{{ photos[0].filename }}" />
+  <meta property="twitter:image" content="{{ request.url_root }}api/thumbor/presets/200x200/{{ photos[0].filename }}" />
+  <meta property="og:image:alt" content="{{ photos[0].caption }}" />
+  <meta property="twitter:image:alt" content="{{ photos[0].caption }}" />
+{% endif %}
+<meta property="og:description" content="{{ site.legend_site }}" />
+<meta property="twitter:description" content="{{ site.legend_site }}" />
+<meta property="og:site_name" content="Geopaysages" />
+<meta property="twitter:site" content="@Geopaysages" />
+{% endif %}
 {% endblock %}
 
 {% block title_mobile %}{{ _('site.title_mobile') }}{% endblock title_mobile %}
@@ -34,14 +53,30 @@
 
 {% block content %}
 
-<div class="mb-4 mt-3 mt-md-2 text-center">
-  <h1 class="text-uppercase">{{ site.name_site }} | {{ site.ville.nom_commune }} 
-  {% if site.ref_site and dbconf.show_site_ref: %}
-    <small class="text-lowercase">(réf. : {{ site.ref_site }})</small>
-  {% endif %}</h1>
-  {% if isMultiObservatories(): %}
-  <h3 class="text-secondary text-uppercase"><img class="mr-2" src="{{ getThumborUrl('fit-in/25x25', site.observatory.logo) }}">{{ site.observatory.title }}</h3>
-  {% endif %}
+<div class="mb-4 mt-3 mt-md-2 px-3 my-4">
+  <div class="row align-items-end">
+    <div class="col-md-3 d-none d-md-block"></div>
+    <div class="col-12 col-md-6 text-center">
+      <h1 class="text-uppercase">{{ site.name_site }} | {{ site.ville.nom_commune }} 
+        {% if site.ref_site and dbconf.show_site_ref: %}
+          <small class="text-lowercase">(réf. : {{ site.ref_site }})</small>
+        {% endif %}
+      </h1>
+      {% if isMultiObservatories(): %}
+        <h3 class="text-secondary text-uppercase">
+          <img class="mr-2" src="{{ getThumborUrl('fit-in/25x25', site.observatory.logo) }}">
+          {{ site.observatory.title }}
+        </h3>
+      {% endif %}
+    </div>
+    {% if dbconf.social_networks %}
+    <div class="col-md-3 d-flex justify-content-end">
+      <div class="social-networks">
+        {% include 'components/social_networks.jinja' %}
+      </div>
+    </div>
+    {% endif %}
+  </div>
 </div>
 
 <div class="page-content container-fluid px-0 px-sm-3 pb-4" id="js-app-site">

--- a/docs/personnalisation.md
+++ b/docs/personnalisation.md
@@ -195,3 +195,55 @@ Reprendre la même procédure que pour la page "À propos", c'est à dire :
 - Éditer le fichier `custom/i18n/fr/LC_MESSAGES/messages.po` 
 - Appliquer les changements `./docker/docker.sh exec backend pybabel compile -d ./i18n && ./docker/docker.sh restart backend`
 - Actualiser la page web, les modifications devraient apparaitres
+
+## Boutons de partage sur les réseaux sociaux
+
+Il est possible d’afficher des boutons de partage sur la fiche site pour les réseaux sociaux de votre choix.  
+Pour cela, il suffit d’ajouter une clé `social_networks` dans la table `conf` de la base de données, avec une valeur JSON listant les réseaux à activer.
+
+**Exemple de valeur à insérer dans la table `conf` :**
+
+```json
+{
+  "facebook": true,
+  "twitter": true,
+  "linkedin": true,
+  "whatsapp": true,
+  "reddit": true,
+  "pinterest": true,
+  "email": true
+}
+```
+
+- Mettez la valeur à `true` pour chaque réseau social que vous souhaitez afficher.
+- Les réseaux supportés sont :  
+  - `facebook`
+  - `twitter`
+  - `linkedin`
+  - `whatsapp`
+  - `reddit`
+  - `pinterest`
+  - `email`
+
+**Exemple de requête SQL pour ajouter la clé :**
+
+```sql
+INSERT INTO conf (key, value)
+VALUES (
+  'social_networks',
+  '{
+    "facebook": true,
+    "twitter": true,
+    "linkedin": true,
+    "whatsapp": true,
+    "reddit": true,
+    "pinterest": true,
+    "email": true
+  }'
+)
+ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
+```
+
+> ⚠️ Pensez à adapter la liste selon vos besoins (mettre `false` pour masquer un bouton).
+
+**Une fois la clé ajoutée, les boutons de partage s’afficheront automatiquement sur la fiche site si le composant Jinja est inclus dans le template.**


### PR DESCRIPTION
- Ajout d’un composant Jinja permettant d’afficher des boutons de partage (Facebook, Twitter, LinkedIn, WhatsApp, Reddit, Pinterest, Email) sur la fiche site/observatoire.
- Activation/désactivation des réseaux via la clé `social_networks` dans la table `conf`.
- Génération automatique des liens de partage avec titre, description et image du site.

> Closes #191